### PR TITLE
Fixed various NtSetTimerResolution problems

### DIFF
--- a/source/plugins/sl.common/commonEntry.cpp
+++ b/source/plugins/sl.common/commonEntry.cpp
@@ -47,6 +47,8 @@
 
 #ifdef SL_WINDOWS
 #define NV_WINDOWS
+// NT_SUCCESS macro
+#include <winternl.h>
 // Needed for SHGetKnownFolderPath
 #include <ShlObj.h>
 #pragma comment(lib,"shlwapi.lib")
@@ -1403,6 +1405,7 @@ void slOnPluginShutdown()
 
 using PFunRtlGetVersion = NTSTATUS(WINAPI*)(PRTL_OSVERSIONINFOW);
 using PFunNtSetTimerResolution = NTSTATUS(NTAPI*)(ULONG DesiredResolution, BOOLEAN SetResolution, PULONG CurrentResolution);
+using PFunNtQueryTimerResolution = NTSTATUS(NTAPI*)(PULONG MinimumResolution, PULONG MaximumResolution, PULONG CurrentResolution);
 
 bool getOSVersionAndUpdateTimerResolution(common::SystemCaps* caps)
 {
@@ -1514,22 +1517,43 @@ bool getOSVersionAndUpdateTimerResolution(common::SystemCaps* caps)
         caps->osVersionBuild = vNT.build;
     }
 
+    auto NtQueryTimerResolution = reinterpret_cast<PFunNtQueryTimerResolution>(GetProcAddress(handle, "NtQueryTimerResolution"));
     auto NtSetTimerResolution = reinterpret_cast<PFunNtSetTimerResolution>(GetProcAddress(handle, "NtSetTimerResolution"));
-    if (NtSetTimerResolution)
+    if (NtSetTimerResolution && NtQueryTimerResolution)
     {
-        ULONG currentRes{};
-        if (!NtSetTimerResolution(5000, TRUE, &currentRes))
+        // Windows supports resolutions higher than 0.5 ms on many systems.
+        //
+        // If Streamline wants 0.5 ms or better timer resolution, it should check if the process is not already using a value smaller (higher resolution).
+        const ULONG slPreferredTimerRes = 5000UL;
+
+        ULONG minRes {ULONG_MAX}, maxRes {slPreferredTimerRes}, setRes {slPreferredTimerRes}, currentRes{ULONG_MAX};
+
+        if (!NT_SUCCESS(NtQueryTimerResolution(&minRes, &maxRes, &currentRes)))
         {
-            SL_LOG_INFO("Changed high resolution timer resolution to 5000 [100 ns units]");
+            SL_LOG_WARN("Failed to query high resolution timer capabilities, assuming it supports at least %u [100 ns units].", slPreferredTimerRes);
         }
-        else
+
+        if (currentRes > slPreferredTimerRes)
         {
-            SL_LOG_WARN("Failed to change high resolution timer resolution to 5000 [100 ns units]");
+            if (maxRes > slPreferredTimerRes)
+            {
+                SL_LOG_INFO("Preferred high resolution timer resolution (%u) is unsupported, trying %u [100 ns units] instead.", slPreferredTimerRes, maxRes);
+                setRes = maxRes;
+            }
+
+            if (NT_SUCCESS(NtSetTimerResolution(setRes, TRUE, &currentRes)))
+            {
+                SL_LOG_INFO("Changed high resolution timer resolution to %u [100 ns units].", currentRes);
+            }
+            else
+            {
+                SL_LOG_WARN("Failed to change high resolution timer resolution to %u [100 ns units].", setRes);
+            }
         }
     }
     else
     {
-        SL_LOG_WARN("Failed to retrieve the NtSetTimerResolution() function from ntdll.");
+        SL_LOG_WARN("Failed to retrieve the NtQueryTimerResolution() and NtSetTimerResolution() functions from ntdll.");
     }
     return res;
 }


### PR DESCRIPTION
+ Ensure Streamline never makes the system timer resolution WORSE than it already was
+ Use the maximum timer resolution available if 0.5 ms is unsupported
+ Handle NTSTATUS checks correctly